### PR TITLE
Clean up buckets on fleet page

### DIFF
--- a/core/templates/core/fleet_view.html
+++ b/core/templates/core/fleet_view.html
@@ -181,10 +181,12 @@
                         <span class="card-title">Bucket {{ bucket.id }}</span>
                     </div>
                     <div class="col s12 m6 right-align">
+                        {% if admin %}
                         <a class="btn "
                            href="{% url 'loot_group_add' fleet.id bucket.id %}"><i
                                 class='material-icons right'>add_circle</i>
                             Add Anom</a>
+                        {% endif %}
                     </div>
                 </div>
 
@@ -199,12 +201,14 @@
         </div>
         {% endfor %}
 
+        {% if admin %}
         <div class="right-align">
             <a class="waves-effect waves-light btn deep-orange lighten-2"
                href="{% url 'loot_group_create' fleet.id %}"><i class='material-icons right'>add_circle</i>Add
 
                 Bucket</a>
         </div>
+        {% endif %}
 
     </div>
 
@@ -219,12 +223,12 @@
 
 
 <script>
-var clipboard = new ClipboardJS('.btn');
+    var clipboard = new ClipboardJS('.btn');
 
-  document.addEventListener('DOMContentLoaded', function() {
-    var elems = document.querySelectorAll('.collapsible');
-    var instances = M.Collapsible.init(elems);
-  });
+    document.addEventListener('DOMContentLoaded', function () {
+        var elems = document.querySelectorAll('.collapsible');
+        var instances = M.Collapsible.init(elems);
+    });
 
 
 </script>


### PR DESCRIPTION
- Use combination of cards and collections to condense how buckets and loot groups are organized/displayed
- Remove unneeded links when clicking the bucket name can serve same purpose
- Shorten button text where possible

![image](https://user-images.githubusercontent.com/5453136/98875882-b8b14980-2442-11eb-84cf-82ea9f10c3f7.png)

This fixes the following bug I've noticed when you're not an admin and there's several buckets (weirdness with row/col spans causing overflows)

![image](https://user-images.githubusercontent.com/5453136/98875950-dbdbf900-2442-11eb-9623-d2e133b39b43.png)

